### PR TITLE
Refactor bot into modules

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,106 @@
+import sys
+import time
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.firefox.service import Service as FirefoxService
+from selenium.webdriver.edge.service import Service as EdgeService
+from webdriver_manager.chrome import ChromeDriverManager
+from pynput.keyboard import Controller
+
+keyboard = Controller()
+
+ERROR_INVALID_ARGUMENTS = "Invalid Arguments"
+
+
+def exit_with_message(error: bool, message: str = "") -> None:
+    """Exit the program after printing a message."""
+    if error:
+        print("Error! Something went wrong!")
+        print("Error Message: " + message)
+    input("Press Enter to exit.")
+    sys.exit(0)
+
+
+def create_driver(browser: str) -> webdriver.Remote:
+    """Create a Selenium driver for the chosen browser."""
+    if browser == "f":
+        return webdriver.Firefox(service=FirefoxService(executable_path="./driver/geckodriver"))
+    if browser == "c":
+        return webdriver.Chrome(service=Service(ChromeDriverManager().install()))
+    if browser == "e":
+        return webdriver.Edge(service=EdgeService("./driver/msedgedriver"))
+    exit_with_message(True, ERROR_INVALID_ARGUMENTS)
+
+
+def login(driver: webdriver.Remote, username: str, password: str) -> None:
+    try:
+        driver.get("https://at4.typewriter.at/index.php?r=site/index")
+        driver.maximize_window()
+        time.sleep(1)
+    except Exception as e:  # pragma: no cover - network errors
+        exit_with_message(True, str(e))
+
+    try:
+        form_login_un = driver.find_element(By.ID, "LoginForm_username")
+        form_login_pw = driver.find_element(By.ID, "LoginForm_pw")
+        form_login_submit = driver.find_element(By.NAME, "yt0")
+    except Exception as e:  # pragma: no cover - element errors
+        exit_with_message(True, str(e))
+
+    time.sleep(1)
+    form_login_un.send_keys(username)
+    form_login_pw.send_keys(password)
+    form_login_submit.click()
+    time.sleep(1)
+
+
+def next_lesson(driver: webdriver.Remote) -> None:
+    time.sleep(1)
+    try:
+        link = driver.find_element(By.CLASS_NAME, "cockpitStartButton")
+        link.click()
+    except Exception as e:  # pragma: no cover - element errors
+        exit_with_message(True, str(e))
+
+
+def do_exercise(driver: webdriver.Remote, speed: int) -> None:
+    keyboard.press(Keys.ENTER)
+    keyboard.release(Keys.ENTER)
+    time.sleep(1)
+
+    try:
+        box = driver.find_element(By.ID, "text_todo_1")
+    except Exception as e:  # pragma: no cover - element errors
+        exit_with_message(True, str(e))
+
+    # remove checkbox
+    keyboard.press(Keys.ENTER)
+    keyboard.release(Keys.ENTER)
+    time.sleep(2.5)
+
+    # find first key
+    current_char = box.find_element(By.TAG_NAME, "span").text
+    keyboard.type(current_char)
+    time.sleep(2.5)
+
+    amount_remaining = driver.find_element(By.ID, "amountRemaining").text
+    remaining = int(amount_remaining)
+
+    while remaining > 0:
+        box = driver.find_element(By.ID, "text_todo_1")
+        current_char = box.find_element(By.TAG_NAME, "span").text
+        keyboard.type(current_char)
+        time.sleep(60 / speed)
+        amount_remaining = driver.find_element(By.ID, "amountRemaining").text
+        remaining = int(amount_remaining)
+
+
+def goto_home_screen(driver: webdriver.Remote) -> None:
+    try:
+        driver.get("https://at4.typewriter.at/index.php?r=user/overview")
+        time.sleep(5)
+    except Exception as e:  # pragma: no cover - network errors
+        exit_with_message(True, str(e))

--- a/typewriterbot.py
+++ b/typewriterbot.py
@@ -1,178 +1,73 @@
-import sys
-from selenium import webdriver
-from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.chrome.service import Service
-from selenium.webdriver.firefox.service import Service as FirefoxService
-from selenium.webdriver.edge.service import Service as EdgeService
-from pynput.keyboard import Controller
 import time
-from selenium.webdriver.chrome.service import Service
-from selenium.webdriver.common.by import By
-from selenium.webdriver.chrome.webdriver import WebDriver
-from webdriver_manager.chrome import ChromeDriverManager
 
-keyboardpy = Controller()
+from bot import (
+    ERROR_INVALID_ARGUMENTS,
+    create_driver,
+    do_exercise,
+    exit_with_message,
+    goto_home_screen,
+    login,
+    next_lesson,
+)
 
-errorList = [
-    "Invalid Arguments",
-    "Connection refused, check internet connection"
-]
 
-def Exit(Error, errorMessage):
-    if Error:
-        print("Error! Something went wrong!")
-        print("Error Message: " + errorMessage)
-    print("Press Enter to exit.")
-    input()
-    sys.exit(0)
+def main() -> None:
+    print("TypeWriterBot by Patrick Cerny, Github: https://github.com/patrickcerny\n")
 
-def Login():
-    print(
-        "Hello User!\nThis is a warning! This application has to use your typetrainer username and password! "
-        "The credentials will not be saved in any way. They serve for login purposes only.\n"
-        "Do you want to continue? (y/n)"
-    )
-    answer = input().strip().lower()
+    browser = input("What browser do you use? (Firefox: F | Chrome: C | Edge: E)\n").strip().lower()
+    if browser not in ["f", "c", "e"]:
+        exit_with_message(True, ERROR_INVALID_ARGUMENTS)
 
-    if answer == "n":
-        Exit(False, "")
+    action = input(
+        "Do you want to log in and do your next exercise, or just do an exercise without login? (Login: L | Exercise: E)\n"
+    ).strip().lower()
 
-    print("Please Enter your Username:")
-    username = input().strip()
-    print("Please Enter your Password:")
-    password = input().strip()
+    try:
+        speed = int(input("What speed do you want to type in? (e.g., 300 => 300 chars/min)\n").strip())
+    except Exception as e:  # pragma: no cover - invalid input
+        exit_with_message(True, str(e))
 
-    if answerBrowser == "f":
-        driver = webdriver.Firefox(service=FirefoxService(executable_path="./driver/geckodriver"))
-    elif answerBrowser == "c":
-        driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()))
-    elif answerBrowser == "e":
-        driver = webdriver.Edge(service=EdgeService("./driver/msedgedriver"))
+    if action == "l":
+        try:
+            times = int(input("How many exercises do you want to do? (1 or more)\n").strip())
+        except Exception as e:
+            exit_with_message(True, str(e))
+
+        print(
+            "Hello User!\nThis is a warning! This application has to use your typetrainer username and password! "
+            "The credentials will not be saved in any way. They serve for login purposes only.\n"
+            "Do you want to continue? (y/n)"
+        )
+        if input().strip().lower() == "n":
+            exit_with_message(False)
+
+        username = input("Please Enter your Username:\n").strip()
+        password = input("Please Enter your Password:\n").strip()
+
+        driver = create_driver(browser)
+        login(driver, username, password)
+        for _ in range(times):
+            next_lesson(driver)
+            do_exercise(driver, speed)
+            time.sleep(1)
+            goto_home_screen(driver)
+
+    elif action == "e":
+        url = input("Please provide the URL of the exercise:\n").strip()
+        driver = create_driver(browser)
+        try:
+            driver.get(url)
+            driver.maximize_window()
+        except Exception as e:  # pragma: no cover - network errors
+            exit_with_message(True, str(e))
+        do_exercise(driver, speed)
     else:
-        Exit(True, errorList[0])
+        exit_with_message(True, ERROR_INVALID_ARGUMENTS)
 
-    try:
-        driver.get("https://at4.typewriter.at/index.php?r=site/index")
-        driver.maximize_window()
-        time.sleep(1)
-    except Exception as e:
-        Exit(True, str(e))
+    print(
+        "Thank you for using my bot! If you have any feedback, please contact me on GitHub: https://github.com/patrickcerny"
+    )
 
-    try:
-        formLogin_un = driver.find_element(By.ID, "LoginForm_username")
-        formLogin_pw = driver.find_element(By.ID, "LoginForm_pw")
-        formLogin_submit = driver.find_element(By.NAME, "yt0")
-    except Exception as e:
-        Exit(True, str(e))
 
-    time.sleep(1)   
-
-    formLogin_un.send_keys(username)
-    formLogin_pw.send_keys(password)
-    formLogin_submit.click()
-
-    time.sleep(1)
-    return driver
-
-def NextLesson(driver):
-    time.sleep(1)
-    try:
-        linkToLesson = driver.find_element(By.CLASS_NAME, "cockpitStartButton")
-        linkToLesson.click()
-    except Exception as e:
-        Exit(True, str(e))
-
-def DoExercise(driver):
-    keyboardpy.press(Keys.ENTER)
-    time.sleep(1)
-    try:
-        box = driver.find_element(By.ID, "text_todo_1")
-        currentChar = box.find_element(By.TAG_NAME, "span").text
-    except Exception as e:
-        Exit(True, str(e))
-
-    # remove checkbox
-    keyboardpy.press(Keys.ENTER)
-    time.sleep(2.5)
-    
-    #find first key
-    currentChar = box.find_element(By.TAG_NAME, "span").text
-    keyboardpy.press(currentChar)
-    time.sleep(2.5)
-
-    amountRemaining = driver.find_element(By.ID, "amountRemaining").text
-    remainingInt = int(amountRemaining)
-
-    while remainingInt > 0:
-        # Locate the input box
-        box = driver.find_element(By.ID, "text_todo_1")
-        # Get the current character from the span inside the box
-        currentChar = box.find_element(By.TAG_NAME, "span").text
-        # Simulate typing the current character
-        keyboardpy.press(currentChar)
-        time.sleep(60 / int(answerSpeed))
-        # Update the remaining count
-        amountRemaining = driver.find_element(By.ID, "amountRemaining").text
-        remainingInt = int(amountRemaining)
-
-def GotoHomeScreen(driver):
-    try:
-        driver.get("https://at4.typewriter.at/index.php?r=user/overview")
-        time.sleep(5)
-    except Exception as e:
-        Exit(True, str(e))
-
-print("TypeWriterBot by Patrick Cerny, Github: https://github.com/patrickcerny\n")
-
-print("What browser do you use? (Firefox: F | Chrome: C | Edge: E)")
-answerBrowser = input().strip().lower()
-if answerBrowser not in ["f", "c", "e"]:
-    Exit(True, errorList[0])
-
-print("Do you want to log in and do your next exercise, or just do an exercise without login? (Login: L | Exercise: E)")
-answer = input().strip().lower()
-
-print("What speed do you want to type in? (e.g., 300 => 300 chars/min)")
-try:
-    answerSpeed = int(input().strip())
-except Exception as e:
-    Exit(True, str(e))
-
-if answer == "l":
-    print("How many exercises do you want to do? (1 or more)")
-    try:
-        timesExercise = int(input().strip())
-    except Exception as e:
-        Exit(True, str(e))
-
-    driver = Login()
-    for _ in range(timesExercise):
-        NextLesson(driver)
-        DoExercise(driver)
-        time.sleep(1)
-        GotoHomeScreen(driver)
-
-elif answer == "e":
-    print("Please provide the URL of the exercise:")
-    url = input().strip()
-    try:
-        if answerBrowser == "f":
-            driver = webdriver.Firefox(service=FirefoxService(executable_path="./driver/geckodriver"))
-        elif answerBrowser == "c":
-            driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()))
-        elif answerBrowser == "e":
-            driver = webdriver.Edge(service=EdgeService("./driver/msedgedriver"))
-        else:
-            Exit(True, errorList[0])
-
-        driver.get(url)
-        driver.maximize_window()
-    except Exception as e:
-        Exit(True, str(e))
-
-    DoExercise(driver)
-else:
-    Exit(True, errorList[0])
-
-print("Thank you for using my bot! If you have any feedback, please contact me on GitHub: https://github.com/patrickcerny")
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- split logic into reusable helpers in `bot.py`
- simplify `typewriterbot.py` entrypoint using helpers

## Testing
- `python -m py_compile bot.py typewriterbot.py`


------
https://chatgpt.com/codex/tasks/task_e_6840013c36a883248c679042b5cd6cb8